### PR TITLE
deployment object should save undercloud credentials,

### DIFF
--- a/fusor-ember-cli/app/controllers/undercloud-deploy.js
+++ b/fusor-ember-cli/app/controllers/undercloud-deploy.js
@@ -114,7 +114,7 @@ export default Ember.Controller.extend(DeploymentControllerMixin, {
 		console.log(response);
             },
             error: function(error) {
-		me.set('deploymentError', 'Undercloud deployment start failed');
+		me.set('deploymentError', error.responseJSON.errors);
 		me.set('showLoadingSpinner', false);
 		console.log('create failed');
 		console.log(error);
@@ -171,7 +171,7 @@ export default Ember.Controller.extend(DeploymentControllerMixin, {
       };
 
       var promise = new Ember.RSVP.Promise(promiseFunction);
-      me.set('loadingSpinnerText', "Deploying Undercloud. This may take a few minutes...");
+      me.set('loadingSpinnerText', "Detecting Undercloud...");
       me.set('showLoadingSpinner', true);
 
     }

--- a/server/app/controllers/fusor/api/openstack/underclouds_controller.rb
+++ b/server/app/controllers/fusor/api/openstack/underclouds_controller.rb
@@ -10,84 +10,50 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'egon/undercloud/commands'
 require 'egon/undercloud/ssh-connection'
-require 'egon/undercloud/installer'
 
 module Fusor
   module Api
     module Openstack
       class UndercloudsController < Api::Openstack::BaseController
 
-        def wait_and_log(installer, stringio)
-          lastpos = 0
-          while !installer.completed?
-            sleep 1
-            current = stringio.size
-            if (lastpos != current)
-              stringio.seek(lastpos)
-              Rails.logger.info stringio.read(current - lastpos)
-              lastpos = current
-            end
-          end
-        end
-
         def show
           deployment = Deployment.find(params[:id])
-          render :json => {:deployed => deployment.undercloud_deployed,
-                           :failed => deployment.undercloud_failed}
+          dep_has_password = deployment.openstack_undercloud_password != nil && not deployment.openstack_undercloud_password.empty?
+          render :json => {:deployed => dep_has_password,
+                           :failed => not dep_has_password}
         end
 
         def create
           deployment = Deployment.find(params[:deployment_id])
+          underhost = params[:underhost]
+          underuser = params[:underuser]
+          underpass = params[:underpass]
 
-          # TODO: will be moved into an action
-          t = Thread.new {
-            underhost = params[:underhost]
-            underuser = params[:underuser]
-            underpass = params[:underpass]
-            satellite_url = params[:satellite_url]
-            satellite_org = params[:satellite_org]
-            satellite_key = params[:satellite_key]
+          ssh = Egon::Undercloud::SSHConnection.new(underhost, underuser, underpass)
+          io = StringIO.new
+          ssh.execute("sudo hiera admin_password", io)
+          admin = io.string.strip
+          io = StringIO.new
+          ssh.execute("sudo hiera controller_host", io)
+          ip_addr = io.string.strip
 
-            ssh = Egon::Undercloud::SSHConnection.new(underhost, underuser, underpass)
-            io = StringIO.new
-            installer = Egon::Undercloud::Installer.new(ssh)
-            installer.install(Egon::Undercloud::Commands.OSP7_satellite(satellite_url, satellite_org, satellite_key), io)
-            wait_and_log(installer, io)
-            deployment.undercloud_failed = installer.failure?
-            Rails.logger.info "undercloud install complete"
-            Rails.logger.info "installer.started? #{installer.started?}"
-            Rails.logger.info "installer.completed? #{installer.completed?}"
-            Rails.logger.info "undercloud install success? #{!installer.failure?}"
+          # This is deplorable, but the undercloud services only listen on the
+          # provisioning network, which may or may not be accessible from here.
+          # See if it is, and if not then throw an error saying so and suggesting
+          # a possible workaround.
+          # See bug https://bugzilla.redhat.com/show_bug.cgi?id=1255412
+          routable = system("ping " + ip_addr + " -c 1 -W 1")
+          if not routable
+            render json: {errors: "Error: The Undercloud's provisioning network is not routable. Please run 'ip route add " + ip_addr + ' via ' + underhost + "' as root on the Satellite and try again."}, status: 422
+            #system('sudo route add ' + ip_addr + ' via ' + underhost)
+          else
+            deployment.openstack_undercloud_password = admin
+            deployment.openstack_undercloud_ip_addr = ip_addr
+            deployment.save(:validate => false)
 
-            if installer.failure?
-              deployment.undercloud_deployed = true
-              deployment.save
-              return
-            end
-
-            installer.check_ports
-            Rails.logger.info "undercloud check_ports success? #{!installer.failure?}"
-            deployment.undercloud_failed = installer.failure?
-
-            if installer.failure?
-              deployment.undercloud_deployed = true
-              deployment.save
-              return
-            end
-
-            io = StringIO.new
-            ssh.execute("sudo hiera admin_password", io)
-            admin = io.string
-            # TODO: save admin credentials, remove logging
-            Rails.logger.info "TODO: remove admin password logging #{admin}"
-
-            deployment.undercloud_deployed = true
-            deployment.save
-          }
-
-          render :json => {:undercloud => deployment.id}
+            render :json => {:undercloud => deployment.id}
+          end
         end
 
       end

--- a/server/db/migrate/20150813000000_add_openstack_attributes_to_deployments.rb
+++ b/server/db/migrate/20150813000000_add_openstack_attributes_to_deployments.rb
@@ -1,6 +1,0 @@
-class AddOpenStackAttributesToDeployments < ActiveRecord::Migration
-  def change
-    add_column :fusor_deployments, :undercloud_deployed, :boolean, :default => false
-    add_column :fusor_deployments, :undercloud_failed,   :boolean, :default => false
-  end
-end

--- a/server/db/migrate/20150825094730_add_undercloud_credentials.rb
+++ b/server/db/migrate/20150825094730_add_undercloud_credentials.rb
@@ -1,0 +1,6 @@
+class AddUndercloudCredentials < ActiveRecord::Migration
+  def change
+    add_column :fusor_deployments, :openstack_undercloud_password, :string
+    add_column :fusor_deployments, :openstack_undercloud_ip_addr, :string
+  end
+end


### PR DESCRIPTION
See if this makes sense, the goal here is to implement some basic changes so that the undercloud deployment page is not actually deploying the undercloud just checking to see if it exists at the specified location and then saving the provisioning network's ip address and the keystone password.
